### PR TITLE
feat: Sentry error telemetry (closes IAP visibility gap)

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -13,6 +13,7 @@ import AnalyticsService from "./services/AnalyticsService";
 import ReviewPromptService from "./services/ReviewPromptService";
 import TipJarService from "./services/TipJarService";
 import StreakService from "./services/StreakService";
+import * as ErrorReporter from "./services/ErrorReporter";
 import { STORAGE_KEYS } from "./config/monetization";
 
 const NOTIFS_ENABLED = process.env.NOTIFS_ENABLED !== 'false';
@@ -72,6 +73,7 @@ function AppContent() {
         if (__DEV__) console.log('[NOTIF] Permissions status:', status);
       } catch (e) {
         if (__DEV__) console.warn("Failed to initialize notifications:", e);
+        ErrorReporter.captureException(e, { where: 'initializeApp' });
       }
     };
 
@@ -106,6 +108,7 @@ function AppContent() {
         }
       } catch (e) {
         if (__DEV__) console.warn("Failed to load state:", e);
+        ErrorReporter.captureException(e, { where: 'loadState' });
       }
     };
 
@@ -117,6 +120,7 @@ function AppContent() {
         if (__DEV__) console.log('[App] Loaded streak stats:', stats);
       } catch (e) {
         if (__DEV__) console.warn('[App] Failed to load streak stats:', e);
+        ErrorReporter.captureException(e, { where: 'loadStreakStats' });
       }
     };
 
@@ -134,6 +138,7 @@ function AppContent() {
         soundRef.current = sound;
       } catch (e) {
         if (__DEV__) console.warn("Chime not loaded. Add assets/chime.mp3", e?.message);
+        ErrorReporter.captureException(e, { where: 'loadChime' });
       }
     })();
     return () => soundRef.current?.unloadAsync();
@@ -179,6 +184,7 @@ function AppContent() {
         if (__DEV__) console.log('[NOTIF] Cancelled notification:', notificationIdRef.current);
       } catch (e) {
         if (__DEV__) console.warn('[NOTIF] Failed to cancel notification:', e);
+        ErrorReporter.captureException(e, { where: 'cancelNotification' });
       }
       notificationIdRef.current = null;
     }
@@ -215,6 +221,7 @@ function AppContent() {
       return id;
     } catch (e) {
       if (__DEV__) console.warn('[NOTIF] Failed to schedule notification:', e);
+      ErrorReporter.captureException(e, { where: 'scheduleOnce', endTime, label });
       return null;
     }
   };
@@ -230,7 +237,10 @@ function AppContent() {
 
   const saveState = async (p, end) => {
     try { await AsyncStorage.setItem(STORAGE_KEYS.TIMER_STATE, JSON.stringify({ phase: p, phaseStartAt: Date.now(), phaseEndAt: end })); }
-    catch (e) { if (__DEV__) console.warn("Failed to save state:", e); }
+    catch (e) {
+      if (__DEV__) console.warn("Failed to save state:", e);
+      ErrorReporter.captureException(e, { where: 'saveState' });
+    }
   };
 
   const startPhase = async (next) => {

--- a/mobile-app/CHANGELOG.md
+++ b/mobile-app/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.7] - 2026-03-29 (Current)
+## [Unreleased]
+
+### Added
+- **Error telemetry via Sentry.** Production-silent catches across the
+  IAP purchase flow, app initialization, notification scheduling,
+  streak service, and review-prompt service now report exceptions to
+  Sentry instead of disappearing. The tip jar purchase flow also emits
+  step-by-step breadcrumbs (connect / getProducts / purchaseItem) and
+  captures the StoreKit error code, so the next time anyone hits the
+  "Oops!" path we'll see what actually failed.
+- `services/ErrorReporter.js` wrapper — components and services never
+  import `@sentry/react-native` directly. Init is gated on `!__DEV__`
+  and an empty DSN is a no-op, so local dev console paths still work.
+- DSN is read from `app.json` `extra.sentryDsn`. Paste a real DSN
+  there before the next prod build to activate.
+
+---
+
+## [1.0.7] - 2026-03-29
 
 ### Changed
 - Expo updated to 54.0.30 for build compatibility

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -53,12 +53,14 @@
             "enableProguardInReleaseBuilds": false
           }
         }
-      ]
+      ],
+      "@sentry/react-native"
     ],
     "extra": {
       "eas": {
         "projectId": "7e0dc02e-4012-4d53-8765-06de09aed23e"
-      }
+      },
+      "sentryDsn": ""
     },
     "owner": "shainaep"
   }

--- a/mobile-app/components/TipJarModal.tsx
+++ b/mobile-app/components/TipJarModal.tsx
@@ -18,6 +18,7 @@ import {
   Platform,
 } from 'react-native';
 import TipJarService from '../services/TipJarService';
+import * as ErrorReporter from '../services/ErrorReporter';
 import { MONETIZATION_CONFIG } from '../config/monetization';
 
 // Conditional import - only load on iOS to avoid Android billing conflicts
@@ -73,38 +74,41 @@ export const TipJarModal: React.FC<TipJarModalProps> = ({
 
   const handleTip = async (productId: string, amount: number) => {
     setPurchasing(true);
+    const iapContext = { productId, amount, trigger, platform: Platform.OS };
+    ErrorReporter.addBreadcrumb('Tip jar purchase started', 'iap', iapContext);
     try {
-      // Connect to store
+      ErrorReporter.addBreadcrumb('IAP connectAsync', 'iap');
       await InAppPurchases.connectAsync();
 
-      // Get products
+      ErrorReporter.addBreadcrumb('IAP getProductsAsync', 'iap', { productId });
       const { results } = await InAppPurchases.getProductsAsync([productId]);
 
       if (!results || results.length === 0) {
         throw new Error('Product not found');
       }
 
-      // Purchase
+      ErrorReporter.addBreadcrumb('IAP purchaseItemAsync', 'iap', { productId });
       await InAppPurchases.purchaseItemAsync(productId);
 
-      // Record donation
       await TipJarService.recordDonation(amount, trigger);
 
-      // Show thank you
       Alert.alert(
         '💚 Thank You!',
         'Your support means the world. It helps keep this app ad-free and independent.',
         [{ text: 'You\'re welcome!', onPress: onClose }]
       );
 
-      // Disconnect from store
       await InAppPurchases.disconnectAsync();
     } catch (error: any) {
-      // User cancelled
       if (error.code === 'E_USER_CANCELLED') {
         if (__DEV__) console.log('[TipJar] User cancelled purchase');
       } else {
         console.error('[TipJar] Purchase error:', error);
+        ErrorReporter.captureException(error, {
+          ...iapContext,
+          errorCode: error?.code,
+          errorMessage: error?.message,
+        });
         Alert.alert(
           'Oops!',
           'Something went wrong. No worries, you weren\'t charged.',

--- a/mobile-app/index.js
+++ b/mobile-app/index.js
@@ -1,8 +1,8 @@
 import { registerRootComponent } from 'expo';
 
 import App from './App';
+import * as ErrorReporter from './services/ErrorReporter';
 
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+ErrorReporter.init();
+
+registerRootComponent(ErrorReporter.wrap(App));

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@sentry/react-native": "~7.2.0",
         "expo": "~54.0.30",
         "expo-av": "~16.0.7",
         "expo-build-properties": "^1.0.10",
@@ -1444,7 +1445,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3473,6 +3473,336 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.12.0.tgz",
+      "integrity": "sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.12.0.tgz",
+      "integrity": "sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.12.0.tgz",
+      "integrity": "sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.12.0.tgz",
+      "integrity": "sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.3.0.tgz",
+      "integrity": "sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.12.0.tgz",
+      "integrity": "sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry-internal/feedback": "10.12.0",
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry-internal/replay-canvas": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.55.0.tgz",
+      "integrity": "sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.55.0",
+        "@sentry/cli-linux-arm": "2.55.0",
+        "@sentry/cli-linux-arm64": "2.55.0",
+        "@sentry/cli-linux-i686": "2.55.0",
+        "@sentry/cli-linux-x64": "2.55.0",
+        "@sentry/cli-win32-arm64": "2.55.0",
+        "@sentry/cli-win32-i686": "2.55.0",
+        "@sentry/cli-win32-x64": "2.55.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.55.0.tgz",
+      "integrity": "sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.55.0.tgz",
+      "integrity": "sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.55.0.tgz",
+      "integrity": "sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.55.0.tgz",
+      "integrity": "sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.55.0.tgz",
+      "integrity": "sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.55.0.tgz",
+      "integrity": "sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.55.0.tgz",
+      "integrity": "sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.55.0.tgz",
+      "integrity": "sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.12.0.tgz",
+      "integrity": "sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.12.0",
+        "@sentry/core": "10.12.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.2.0.tgz",
+      "integrity": "sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "4.3.0",
+        "@sentry/browser": "10.12.0",
+        "@sentry/cli": "2.55.0",
+        "@sentry/core": "10.12.0",
+        "@sentry/react": "10.12.0",
+        "@sentry/types": "10.12.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.12.0.tgz",
+      "integrity": "sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -7941,6 +8271,21 @@
         "hermes-estree": "0.29.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -11205,6 +11550,48 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -12019,6 +12406,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/psl": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -53,7 +53,7 @@
       "./jest-setup.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg))"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/.*|native-base|react-native-svg))"
     ]
   },
   "private": true

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/react-native": "~7.2.0",
     "expo": "~54.0.30",
     "expo-av": "~16.0.7",
     "expo-build-properties": "^1.0.10",

--- a/mobile-app/services/ErrorReporter.js
+++ b/mobile-app/services/ErrorReporter.js
@@ -1,0 +1,35 @@
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+const dsn = Constants.expoConfig?.extra?.sentryDsn ?? '';
+let initialized = false;
+
+export function init() {
+  if (__DEV__ || !dsn) return;
+  Sentry.init({
+    dsn,
+    enableAutoSessionTracking: true,
+    tracesSampleRate: 0,
+  });
+  initialized = true;
+}
+
+export function captureException(error, context) {
+  if (__DEV__) {
+    console.warn('[ErrorReporter] captureException:', error, context);
+    return;
+  }
+  if (!initialized) return;
+  Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+export function addBreadcrumb(message, category, data) {
+  if (__DEV__) {
+    console.log(`[ErrorReporter] breadcrumb [${category}] ${message}`, data ?? '');
+    return;
+  }
+  if (!initialized) return;
+  Sentry.addBreadcrumb({ message, category, level: 'info', data });
+}
+
+export const wrap = Sentry.wrap;

--- a/mobile-app/services/ReviewPromptService.js
+++ b/mobile-app/services/ReviewPromptService.js
@@ -2,6 +2,7 @@
 import * as StoreReview from 'expo-store-review';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AnalyticsService from './AnalyticsService';
+import * as ErrorReporter from './ErrorReporter';
 import { STORAGE_KEYS, MONETIZATION_CONFIG } from '../config/monetization';
 
 /**
@@ -59,6 +60,7 @@ class ReviewPromptService {
       return true;
     } catch (error) {
       if (__DEV__) console.warn('[Review] Error requesting review:', error);
+      ErrorReporter.captureException(error, { where: 'ReviewPromptService.requestReview', trigger });
       return false;
     }
   }
@@ -94,6 +96,7 @@ class ReviewPromptService {
       return true;
     } catch (error) {
       if (__DEV__) console.warn('[Review] Error checking eligibility:', error);
+      ErrorReporter.captureException(error, { where: 'ReviewPromptService.shouldPromptReview' });
       return false;
     }
   }
@@ -118,6 +121,7 @@ class ReviewPromptService {
       if (__DEV__) console.log(`[Review] Prompt ${newCount}/3 shown (${trigger})`);
     } catch (error) {
       if (__DEV__) console.warn('[Review] Error recording prompt:', error);
+      ErrorReporter.captureException(error, { where: 'ReviewPromptService.recordPromptShown', trigger });
     }
   }
 
@@ -143,6 +147,7 @@ class ReviewPromptService {
       return newCount;
     } catch (error) {
       if (__DEV__) console.warn('[Review] Error incrementing sessions:', error);
+      ErrorReporter.captureException(error, { where: 'ReviewPromptService.incrementTotalSessions' });
       return 0;
     }
   }
@@ -239,6 +244,7 @@ class ReviewPromptService {
       return count;
     } catch (error) {
       if (__DEV__) console.warn('[Review] Error incrementing daily sessions:', error);
+      ErrorReporter.captureException(error, { where: 'ReviewPromptService.incrementDailySessionCount' });
       return 0;
     }
   }

--- a/mobile-app/services/StreakService.js
+++ b/mobile-app/services/StreakService.js
@@ -9,6 +9,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as ErrorReporter from './ErrorReporter';
 import { STORAGE_KEYS } from '../config/monetization';
 
 class StreakService {
@@ -87,6 +88,7 @@ class StreakService {
       };
     } catch (error) {
       console.error('[Streak] Error recording session:', error);
+      ErrorReporter.captureException(error, { where: 'StreakService.recordFocusSession' });
       return { streak: 0, lifetimeSessions: 0, isNewDay: false, message: '' };
     }
   }
@@ -124,6 +126,7 @@ class StreakService {
       };
     } catch (error) {
       console.error('[Streak] Error getting stats:', error);
+      ErrorReporter.captureException(error, { where: 'StreakService.getStats' });
       return { streak: 0, lifetimeSessions: 0 };
     }
   }


### PR DESCRIPTION
## Summary
- Wires `@sentry/react-native` via a thin `ErrorReporter` wrapper so call sites never import the SDK directly.
- Adds step-by-step breadcrumbs through the tip jar IAP flow (`connect` → `getProducts` → `purchaseItem`) and captures any non-cancel failure with `productId`, `amount`, `trigger`, `platform`, and the StoreKit `error.code`.
- Routes the previously-silent catches in `App.js` (init, state load, streak load, audio load, notification cancel/schedule, save state), `StreakService`, and `ReviewPromptService` through `ErrorReporter` so they no longer disappear in production.

## Motivation
Yesterday's "Oops! Something went wrong" alert on the live tip jar was invisible to us — the catch only did `console.error`. Root cause turned out to be the Paid Apps Agreement (resolved separately), but the visibility gap remains: future StoreKit failures, account-state issues, network blips, or `expo-in-app-purchases` deprecation incidents would all hit the same dead end. This PR closes that class of bug.

Best-effort catches inside the tick interval (audio replay + haptics) are intentionally left as empty catches — they fire too often and aren't actionable.

## Before merging / next build
Paste a real DSN into `mobile-app/app.json` at `extra.sentryDsn`. Until then `ErrorReporter.init()` is a no-op — won't break anything, just won't report. Two paths: reuse an existing Sentry project, or create a new one named `pomodoroflow`.

## Test plan
- [x] `npm test` — 6/6 pass (PR #14's new state-machine coverage included)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 1 pre-existing warning (intentional iOS-only `require()` in `TipJarModal.tsx`)
- [ ] After DSN is pasted: build preview, force a tip jar failure (e.g. revoke sandbox account), confirm event lands in Sentry with breadcrumbs + StoreKit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)