### PR TITLE
fix: dynamic copyright year in landing + release-notes footers

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
     </main>
 
     <footer>
-      <div>© 2025 PomodoroFlow • By Shaina Pauley</div>
+      <div>© <span id="year">2026</span> PomodoroFlow • By Shaina Pauley</div>
       <div class="links">
         <a href="release-notes.html">Release Notes</a>
         <a href="privacy.html">Privacy</a>
@@ -205,5 +205,8 @@
       </div>
     </footer>
   </div>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/release-notes.html
+++ b/release-notes.html
@@ -397,7 +397,7 @@
 
     <!-- Footer -->
     <footer>
-      <div>© 2025 PomodoroFlow • By Shaina Pauley</div>
+      <div>© <span id="year">2026</span> PomodoroFlow • By Shaina Pauley</div>
       <div class="links">
         <a href="/">Home</a>
         <a href="release-notes.html">Release Notes</a>
@@ -413,6 +413,7 @@
     if (typeof feather !== 'undefined') {
       feather.replace();
     }
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Wraps the year in `<span id="year">…</span>` and sets it via `new Date().getFullYear()` on page load.
- Bumped the static fallback to 2026 (correct today, no longer stale).
- Touched `index.html` and `release-notes.html`. `privacy.html` and `404.html` have no footer year — left alone.

## Why
Footer read "© 2025 PomodoroFlow" mid-2026. Bumping it manually each January is a class of bug that's better closed once: now the year self-updates forever, with a static fallback for the rare no-JS reader.

## Test plan
- [x] Open `index.html` in a browser — footer shows the current year
- [x] Open `release-notes.html` in a browser — same
- [ ] Vercel preview deploy confirms the same behavior on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)