### PR TITLE
fix(build): add @expo/config-plugins peer dep

### DIFF
--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "pomodoroflow-mobile",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoroflow-mobile",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
+        "@expo/config-plugins": "~56.0.0",
         "@expo/metro-runtime": "~56.0.19",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -1498,6 +1499,45 @@
         "node-forge": "^1.3.3"
       }
     },
+    "node_modules/@expo/config-plugins": {
+      "version": "56.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.15.tgz",
+      "integrity": "sha512-MsSko6coyBWgx7oWFFETxAZZtGJlYykCuCKAGxYgzfT1leUxPVNg1FuGD9moPObDxGadB9l6GJeDuaM2tuCmsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^56.0.7",
+        "@expo/json-file": "~10.2.0",
+        "@expo/plist": "^0.7.0",
+        "@expo/require-utils": "^56.1.6",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/config-types": {
+      "version": "56.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
+      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
+      "license": "MIT"
+    },
     "node_modules/@expo/devcert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz",
@@ -1632,25 +1672,6 @@
         "semver": "^7.6.0"
       }
     },
-    "node_modules/@expo/image-utils/node_modules/@expo/require-utils": {
-      "version": "56.1.6",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
-      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@expo/image-utils/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1672,34 +1693,7 @@
         "@expo/config-plugins": "~56.0.14"
       }
     },
-    "node_modules/@expo/inline-modules/node_modules/@expo/config-plugins": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.14.tgz",
-      "integrity": "sha512-pdjBwH67BF1dnim4N/OxgBshhil27eu3C9uuhwzzK2Bnzl6bIcdt9WjEVuMXluFnEpWe0ws5sxE8NvBR5Ms7bQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^56.0.7",
-        "@expo/json-file": "~10.2.0",
-        "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.6",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/config-types": {
-      "version": "56.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
-      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/json-file": {
+    "node_modules/@expo/json-file": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
       "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
@@ -1707,48 +1701,6 @@
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/plist": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
-      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/@expo/require-utils": {
-      "version": "56.1.6",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
-      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/inline-modules/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
@@ -1777,73 +1729,6 @@
         "resolve-workspace-root": "^2.0.0",
         "semver": "^7.6.0",
         "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/config-plugins": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.14.tgz",
-      "integrity": "sha512-pdjBwH67BF1dnim4N/OxgBshhil27eu3C9uuhwzzK2Bnzl6bIcdt9WjEVuMXluFnEpWe0ws5sxE8NvBR5Ms7bQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^56.0.7",
-        "@expo/json-file": "~10.2.0",
-        "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.6",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/config-types": {
-      "version": "56.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
-      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/json-file": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
-      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/plist": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
-      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@expo/require-utils": {
-      "version": "56.1.6",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
-      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@expo/local-build-cache-provider/node_modules/semver": {
@@ -1973,6 +1858,17 @@
         "json5": "^2.2.3"
       }
     },
+    "node_modules/@expo/plist": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
+      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
     "node_modules/@expo/prebuild-config": {
       "version": "56.0.21",
       "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.21.tgz",
@@ -2009,55 +1905,19 @@
         "slugify": "^1.3.4"
       }
     },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/config-plugins": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.14.tgz",
-      "integrity": "sha512-pdjBwH67BF1dnim4N/OxgBshhil27eu3C9uuhwzzK2Bnzl6bIcdt9WjEVuMXluFnEpWe0ws5sxE8NvBR5Ms7bQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^56.0.7",
-        "@expo/json-file": "~10.2.0",
-        "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.6",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
+    "node_modules/@expo/prebuild-config/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/config-types": {
-      "version": "56.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
-      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/json-file": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
-      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/plist": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
-      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/require-utils": {
+    "node_modules/@expo/require-utils": {
       "version": "56.1.6",
       "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
       "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
@@ -2074,18 +1934,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@expo/schema-utils": {
@@ -6913,25 +6761,6 @@
         "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
       }
     },
-    "node_modules/expo-modules-autolinking/node_modules/@expo/require-utils": {
-      "version": "56.1.6",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
-      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/expo-modules-core": {
       "version": "56.0.23",
       "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.23.tgz",
@@ -7134,43 +6963,6 @@
         "slugify": "^1.3.4"
       }
     },
-    "node_modules/expo/node_modules/@expo/config-plugins": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.14.tgz",
-      "integrity": "sha512-pdjBwH67BF1dnim4N/OxgBshhil27eu3C9uuhwzzK2Bnzl6bIcdt9WjEVuMXluFnEpWe0ws5sxE8NvBR5Ms7bQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^56.0.7",
-        "@expo/json-file": "~10.2.0",
-        "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.6",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/config-types": {
-      "version": "56.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
-      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/@expo/json-file": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
-      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
-      }
-    },
     "node_modules/expo/node_modules/@expo/metro-config": {
       "version": "56.0.18",
       "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.18.tgz",
@@ -7206,36 +6998,6 @@
       },
       "peerDependenciesMeta": {
         "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/plist": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
-      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/require-utils": {
-      "version": "56.1.6",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.6.tgz",
-      "integrity": "sha512-e68r6X+c7yPxJP0gac/CaJc/RCHeLB2Bf4MyCuqfNM4YXfl1ONmQbQlRL0RbwBfEHn6A6UZKj+5UX9j0Im646g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -20,6 +20,7 @@
     "build:android": "eas build --platform android"
   },
   "dependencies": {
+    "@expo/config-plugins": "~56.0.0",
     "@expo/metro-runtime": "~56.0.19",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",


### PR DESCRIPTION
## Summary

EAS builds fail on both platforms with \`Cannot find module '@expo/config-plugins'\` from the Sentry Expo plugin's require chain. \`@sentry/react-native\`'s Expo plugin needs \`@expo/config-plugins\` as a peer, but SDK 56 no longer surfaces it transitively — we need it as a direct dep.

Discovered while kicking off the 1.0.8 production builds — dep-add unblocks them.

## Test plan

- [x] \`npx expo config --json\` now succeeds
- [ ] CI green on PR
- [ ] EAS builds succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)