### PR TITLE
fix(build): pin latest EAS image + Sentry env vars

### DIFF
--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -13,8 +13,12 @@
     },
     "production": {
       "autoIncrement": true,
+      "image": "latest",
       "env": {
-        "NODE_ENV": "production"
+        "NODE_ENV": "production",
+        "SENTRY_ORG": "shaina-pauley",
+        "SENTRY_PROJECT": "pomodoroflow",
+        "SENTRY_ALLOW_FAILURE": "true"
       }
     }
   },


### PR DESCRIPTION
## Summary

Two production-build failures on the first 1.0.8 EAS run:

**iOS** — openiap 3.0.1 (expo-iap's native dep) compiles against iOS 26 StoreKit types. EAS default Xcode image doesn't have iOS 26 SDK. Pinning \`image: "latest"\`.

**Android** — Sentry gradle source-map upload failed: "An organization ID or slug is required". The plugin's warning during install told us env vars are the fallback path. Added \`SENTRY_ORG\` + \`SENTRY_PROJECT\` + \`SENTRY_ALLOW_FAILURE=true\` (so absence of SENTRY_AUTH_TOKEN doesn't kill the build).

## Follow-up (post-ship, not blocking)

- Add \`SENTRY_AUTH_TOKEN\` as an EAS secret → source maps upload properly → Sentry symbolicates JS stack traces instead of showing minified frames.

## Test plan

- [ ] CI green on PR
- [ ] EAS iOS production build succeeds
- [ ] EAS Android production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)