### PR TITLE
fix(build): move image key under per-platform blocks in eas.json

### DIFF
--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -13,7 +13,12 @@
     },
     "production": {
       "autoIncrement": true,
-      "image": "latest",
+      "ios": {
+        "image": "latest"
+      },
+      "android": {
+        "image": "latest"
+      },
       "env": {
         "NODE_ENV": "production",
         "SENTRY_ORG": "shaina-pauley",


### PR DESCRIPTION
`build.production.image` schema requires it nested under `ios` and `android` separately, not at profile root. My bad on PR #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)