### PR TITLE
fix: expo-av → expo-audio + revert Android to default EAS image

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,7 +1,7 @@
 // mobile-app/App.js
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Pressable, StyleSheet, Switch, AppState, Platform, Modal, Alert } from "react-native";
-import { Audio } from "expo-av";
+import { createAudioPlayer } from "expo-audio";
 import * as Notifications from "expo-notifications";
 import * as Haptics from "expo-haptics";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -47,7 +47,7 @@ function AppContent() {
   const notificationIdRef = useRef(null);  // currently scheduled local notif id
   const lastScheduleKeyRef = useRef(null); // prevent duplicate scheduling
   const appState = useRef(AppState.currentState);
-  const soundRef = useRef(null);
+  const playerRef = useRef(null);
 
   useEffect(() => {
     const initializeApp = async () => {
@@ -130,18 +130,14 @@ function AppContent() {
   }, [durations]);
 
   useEffect(() => {
-    (async () => {
-      try {
-        // Removed setAudioModeAsync to avoid UIBackgroundModes audio requirement (App Store Guideline 2.5.4)
-        // Sound will now respect device silent mode - this is acceptable for a pomodoro timer chime
-        const { sound } = await Audio.Sound.createAsync(require("./assets/chime.mp3"));
-        soundRef.current = sound;
-      } catch (e) {
-        if (__DEV__) console.warn("Chime not loaded. Add assets/chime.mp3", e?.message);
-        ErrorReporter.captureException(e, { where: 'loadChime' });
-      }
-    })();
-    return () => soundRef.current?.unloadAsync();
+    // Chime respects device silent mode (no UIBackgroundModes audio — App Store Guideline 2.5.4)
+    try {
+      playerRef.current = createAudioPlayer(require("./assets/chime.mp3"));
+    } catch (e) {
+      if (__DEV__) console.warn("Chime not loaded. Add assets/chime.mp3", e?.message);
+      ErrorReporter.captureException(e, { where: 'loadChime' });
+    }
+    return () => playerRef.current?.remove();
   }, []);
 
   useEffect(() => {
@@ -301,7 +297,10 @@ function AppContent() {
 
       const now = Date.now();
       if (now >= end) {
-        try { await soundRef.current?.replayAsync(); } catch {}
+        try {
+          playerRef.current?.seekTo(0);
+          playerRef.current?.play();
+        } catch {}
         try { await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success); } catch {}
 
         // Track session completion

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -57,7 +57,8 @@
       "@sentry/react-native",
       "expo-asset",
       "expo-font",
-      "expo-iap"
+      "expo-iap",
+      "expo-audio"
     ],
     "extra": {
       "eas": {

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -16,9 +16,6 @@
       "ios": {
         "image": "latest"
       },
-      "android": {
-        "image": "latest"
-      },
       "env": {
         "NODE_ENV": "production",
         "SENTRY_ORG": "shaina-pauley",

--- a/mobile-app/jest-setup.js
+++ b/mobile-app/jest-setup.js
@@ -42,18 +42,13 @@ jest.mock('expo-haptics', () => ({
   },
 }));
 
-jest.mock('expo-av', () => ({
-  Audio: {
-    setAudioModeAsync: jest.fn(() => Promise.resolve()),
-    Sound: {
-      createAsync: jest.fn(() => Promise.resolve({
-        sound: {
-          replayAsync: jest.fn(() => Promise.resolve()),
-          unloadAsync: jest.fn(() => Promise.resolve()),
-        }
-      }))
-    }
-  }
+jest.mock('expo-audio', () => ({
+  createAudioPlayer: jest.fn(() => ({
+    play: jest.fn(),
+    pause: jest.fn(),
+    seekTo: jest.fn(),
+    remove: jest.fn(),
+  })),
 }));
 
 jest.mock('expo-iap', () => ({

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -17,7 +17,7 @@
         "babel-preset-expo": "~56.0.0",
         "expo": "~56",
         "expo-asset": "~56.0.22",
-        "expo-av": "~16.0.7",
+        "expo-audio": "~56.0.13",
         "expo-build-properties": "~56.0.25",
         "expo-constants": "~56.0.23",
         "expo-font": "~56.0.7",
@@ -6634,6 +6634,7 @@
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.22.tgz",
       "integrity": "sha512-KIlIskLTD1a/rtoEIiJv0IeRAnnxRavD2oLyHI0aCEs4zl0yNHM2xLZHh05PWvAHJbBlbopfOWW1g8IbJp6ttg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/image-utils": "^0.10.4",
         "expo-constants": "~56.0.23"
@@ -6644,21 +6645,16 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-av": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
-      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
+    "node_modules/expo-audio": {
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.13.tgz",
+      "integrity": "sha512-pfBmT/8OYbhrb37ECk+fC1EstLBFxMTioF4uZrAEeOj3uCgjproj1qYmkpsQLJIoEOMPSIw1iSfBEMl10v1DDA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
+        "expo-asset": "*",
         "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
+        "react-native": "*"
       }
     },
     "node_modules/expo-build-properties": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -28,7 +28,7 @@
     "babel-preset-expo": "~56.0.0",
     "expo": "~56",
     "expo-asset": "~56.0.22",
-    "expo-av": "~16.0.7",
+    "expo-audio": "~56.0.13",
     "expo-build-properties": "~56.0.25",
     "expo-constants": "~56.0.23",
     "expo-font": "~56.0.7",


### PR DESCRIPTION
## Summary

Second-round build failures after PR #20:

- **iOS:** expo-av is deprecated and its ObjC bridge was removed in SDK 56 → \`EXEventEmitter.h\` file not found. Migrated App.js to expo-audio (\`createAudioPlayer\` / \`play\` / \`seekTo\` / \`remove\`).
- **Android:** \`image: "latest"\` = SDK 57 preview, crashes Kotlin compiler on expo module. Earlier build with default image compiled fine. Reverted Android to default; iOS keeps \`latest\` (needed for iOS 26 StoreKit).

## Test plan

- [x] 14/14 tests pass
- [x] Typecheck + lint clean
- [ ] CI green on PR
- [ ] Both EAS builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)