### PR TITLE
fix(android): pin kotlinVersion 2.4.10 to match stdlib

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -50,7 +50,8 @@
         "expo-build-properties",
         {
           "android": {
-            "enableProguardInReleaseBuilds": false
+            "enableProguardInReleaseBuilds": false,
+            "kotlinVersion": "2.4.10"
           }
         }
       ],


### PR DESCRIPTION
Android Kotlin compilation failed with 100+ Unresolved reference errors — dep graph pulled kotlin-stdlib 2.4.10 but compiler was 2.1.0. Pinning kotlinVersion in expo-build-properties to 2.4.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)