### PR TITLE
fix(android): upgrade expo-iap 5.1.0 → 5.3.1

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -50,8 +50,7 @@
         "expo-build-properties",
         {
           "android": {
-            "enableProguardInReleaseBuilds": false,
-            "kotlinVersion": "2.4.10"
+            "enableProguardInReleaseBuilds": false
           }
         }
       ],

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -22,7 +22,7 @@
         "expo-constants": "~56.0.23",
         "expo-font": "~56.0.7",
         "expo-haptics": "~56.0.3",
-        "expo-iap": "^5.1.0",
+        "expo-iap": "^5.3.1",
         "expo-notifications": "~56.0.23",
         "expo-store-review": "~56.0.3",
         "react": "19.2.3",
@@ -6722,9 +6722,9 @@
       }
     },
     "node_modules/expo-iap": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/expo-iap/-/expo-iap-5.1.0.tgz",
-      "integrity": "sha512-gaU133mjRG19dwoMbyepJdmbSt+XG8N0ELJEH3BVGbfcPkFhxZFKcAGxGVfbqA2xXGFXcHvrwTrXmWwVXuyQfw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/expo-iap/-/expo-iap-5.3.1.tgz",
+      "integrity": "sha512-XEGcZrzpKH9krdVKPc2saC4+qQx3xKtfejtgQVWCungmL6wzquk6xkwhTZjfxPcFwd3qxD7BK1ItXEyTeYf6Bg==",
       "license": "MIT",
       "peerDependencies": {
         "@amazon-devices/keplerscript-appstore-iap-lib": "~2.13.0",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -33,7 +33,7 @@
     "expo-constants": "~56.0.23",
     "expo-font": "~56.0.7",
     "expo-haptics": "~56.0.3",
-    "expo-iap": "^5.1.0",
+    "expo-iap": "^5.3.1",
     "expo-notifications": "~56.0.23",
     "expo-store-review": "~56.0.3",
     "react": "19.2.3",


### PR DESCRIPTION
The Kotlin metadata mismatch was tracked to `openiap-google 3.1.0` (expo-iap 5.1.0's bundled lib) pulling in bleeding-edge kotlin-stdlib 2.4.10. expo-iap 5.3.1 bundles openiap-google 3.3.1 which no longer depends on billing-ktx (source: [hyochan/expo-iap#300](https://github.com/hyochan/expo-iap/issues/300)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)