### PR TITLE
chore(eas): add android submit profile (internal track)

### DIFF
--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -28,6 +28,9 @@
     "production": {
       "ios": {
         "ascAppId": "6753604260"
+      },
+      "android": {
+        "track": "internal"
       }
     }
   }


### PR DESCRIPTION
`eas submit --platform android` doesn't accept `--track` as a flag — belongs in eas.json's `submit.production.android` block. Adding with default `internal` track.

Post-Play-Console-approval, we promote internal → production in Play Console UI (no rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)